### PR TITLE
Add middleware for getting signed request only

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,40 @@ on the backend:
 
 Middleware:
 ----------
+
+### django_facebook.middleware.FacebookSignedRequestMiddleware:
+
+This provides access to Facebook's signed_request. This is useful
+for Page Tabs, where you won't have access to a real Facebook User
+since they have not granted you permission to the app.
+
+Adding this to MIDDLEWARE_CLASSES will add the 'signed_request'
+attribute to the request.  Building a "Like Gate" becomes trivial.  A
+Django template to do this could look like this:
+
+    {% load facebook %}
+    <!DOCTYPE html>
+    <html>
+    <head>
+        {% facebook_init %}
+        {% block facebook_code %}{% endblock %}
+        {% endfacebook %}
+        <title>Like us!</title>
+    </head>
+    <body>
+        {% if not signed_request.page.liked %}
+        <h1>LIKE us on Facebook!</h1>
+        {% else %}
+        <h1>Thank you for liking us on Facebook</h1>
+    </body>
+    {% facebook_load %}
+    </html>
+
+Documentation on the signed_request (especially as it relates to Page Tabs)
+can be found on Facebook's developer site.
+
+### django_facebook.middleware.FacebookMiddleware:
+
 This provides seamless access to the Facebook Graph via request object.
 
 If a user accesses your site with:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Django template to do this could look like this:
     </html>
 
 Documentation on the signed_request (especially as it relates to Page Tabs)
-can be found on Facebook's developer site.
+can be found on [Facebook's developer
+site](https://developers.facebook.com/blog/post/462/).
 
 ### django_facebook.middleware.FacebookMiddleware:
 

--- a/django_facebook/middleware.py
+++ b/django_facebook/middleware.py
@@ -61,6 +61,34 @@ class FacebookDebugTokenMiddleware(object):
         request.facebook = DjangoFacebook(user)
         return None
 
+class FacebookSignedRequestMiddleware(object):
+    """
+    Only process the signed request from Facebook, don't
+    transparently login the user.
+
+    """
+
+    def process_request(self, request):
+        """
+        Add 'fb_signed_request' into the request context
+
+        If no signed request was found, request.fb_signed_request will be None. Otherwise it will
+        contain a dict object containing the contents of the signed_request.
+
+        if a FB user is present, create request.facebook that contains the user.
+
+        """
+
+        if request.POST.get('signed_request'):
+            signed_request = request.POST["signed_request"]
+            data = facebook.parse_signed_request(signed_request,
+                                                 settings.FACEBOOK_SECRET_KEY)
+            if data:
+                request.fb_signed_request = data
+            else:
+                request.fb_signed_request = None
+
+        return None
 
 class FacebookMiddleware(object):
     """


### PR DESCRIPTION
This pull request adds django_facebook.middleware.FacebookSignedRequestMiddleware, which decodes a signed_request that comes from Facebook and adds it to Django's request variable.

This is useful for building simple "Like Gates".
